### PR TITLE
Consider switching to using easyfft

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ soapysdr = ["dep:soapysdr"]
 [dependencies]
 soapysdr = { version = "0.3.2", optional = true }
 num = "0.4.0"
-rustfft = "6.0.1"
+easyfft = "0.3.5"
 cpal = { version = "0.14.0", optional = true }
 tokio = { version = "1.21.1", features = ["full"] }
 

--- a/src/numbers.rs
+++ b/src/numbers.rs
@@ -3,7 +3,7 @@
 //! This module re-exports [`num::Complex`] as [`Complex`] and provides a
 //! [`Float`] trait, which is implemented by [`f32`] and [`f64`].
 
-use rustfft::FftNum;
+use easyfft::FftNum;
 
 use std::marker::{Send, Sync};
 
@@ -27,6 +27,7 @@ where
     Self: num::traits::FloatConst,
     Self: num::traits::NumAssignOps,
     Self: FftNum,
+    Self: Default,
 {
 }
 impl<T> Float for T
@@ -36,6 +37,7 @@ where
     T: num::traits::FloatConst,
     T: num::traits::NumAssignOps,
     T: FftNum,
+    Self: Default,
 {
 }
 


### PR DESCRIPTION
Currently the FftPlanner structure is created each time a fft is performed. It's computationally expensive to re-generate the planner structure each time and ergonomically expensive to manage the planner manually.

easyfft does this for you using thread-local storage behind the scenes.

# Note:
This is a breaking change! It adds an extra `Default` trait bound to the `Float` trait.